### PR TITLE
`git log` is performed with --pretty=oneline

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -101,8 +101,8 @@ function build_prompt {
 	can_fast_forward=false
 	can_fast_forward=false
 
-	commits_ahead=$(git log --topo-order --left-right ${current_commit_hash}...${upstream} | grep -c "^<" )
-	commits_behind=$(git log --topo-order --left-right ${current_commit_hash}...${upstream} | grep -c "^>" )
+	commits_ahead=$(git log --pretty=oneline --topo-order --left-right ${current_commit_hash}...${upstream} | grep -c "^<" )
+	commits_behind=$(git log --pretty=oneline --topo-order --left-right ${current_commit_hash}...${upstream} | grep -c "^>" )
 
 	if [ ${commits_ahead} -gt 0 -a ${commits_behind} -gt 0  ];
 	then


### PR DESCRIPTION
On my laptop (mac os X 10.8.4, git 1.8.3.3) the result of `git log --topo-order --left-right ${current_commit_hash}...${upstream}` is something like this :

```
commit < 2b08f527038d1464ae03098ace6bb4b6efd44c69
Author: fcamblor <fcamblor@xxxx.com>
Date:   Wed Sep 11 17:49:24 2013 +0200

    An empty commit
```

So the `grep` command doesn't count anything here.
I think you're missing some `--pretty=oneline` argument here (maybe defaulted in your ~/.gitconfig file ?)

Wondering if `number_of_logs` variable should be affected too, WDYT ?
