### PR TITLE
Added possibility to clone repository anywhere rather than in the $HOME

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -1,6 +1,6 @@
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
 if [ -n "${BASH_VERSION}" ]; then
+    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
     # Symbols
     : ${is_a_git_repo_symbol:='❤'}
     : ${has_untracked_files_symbol:='∿'}


### PR DESCRIPTION
I usually want to keep my home-directory clean. This pull request makes it possible to clone the repository anywhere you like. Seems to work ok in bash at least.
