### PR TITLE
Prompt callback can be used to inject a generic function

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,37 @@ or just move the startup command
 
 from ```.profile``` to ```.bash_profile```
 
+**Q**: Hey, where's my current virtualenv name? It disappeared from the prompt! Or it appears like this
+
+![virtualenv badly rendered](https://cloud.githubusercontent.com/assets/150719/5852434/06933e88-a217-11e4-81a0-153c5a300b0a.png)
+
+**A**: Yes, actually the virtualenv's approach with prompts is pretty disappointing (see [Virtualenv's bin/activate is Doing It Wrong](https://gist.github.com/datagrok/2199506)): in fact, the script ```activate``` performs a
+
+```
+PS1="(`basename \"$VIRTUAL_ENV\"`)$PS1"
+```
+
+that arrogantly prepends the virtualenv name to the current ```PS1```, leaving you no opportunity to customise the output.
+
+You can solve this problem disabling the standart virtualenv prompt injection and using the callback function `omg_prompt_callback`.
+
+Add
+
+```
+VIRTUAL_ENV_DISABLE_PROMPT=true
+function omg_prompt_callback() {
+    if [ -n "${VIRTUAL_ENV}" ]; then
+        echo "\e[0;31m(`basename ${VIRTUAL_ENV}`)\e[0m "
+    fi
+}
+```
+
+to your shell startup script. It should render the prompt inside an active virtualenv like this
+
+![a proper virtualenv rendering](https://cloud.githubusercontent.com/assets/150719/5852429/e50d18a6-a216-11e4-9b0e-c902f47a1ca4.png)]
+
+You can use the call back function to inject whatever you want at the beginning of the second line.
+
 # Known bugs and limitations
 
 * git v1.8.4 or newer is required

--- a/base.sh
+++ b/base.sh
@@ -111,3 +111,12 @@ function build_prompt {
     echo "$(custom_build_prompt ${enabled:-true} ${current_commit_hash:-""} ${is_a_git_repo:-false} ${current_branch:-""} ${detached:-false} ${just_init:-false} ${has_upstream:-false} ${has_modifications:-false} ${has_modifications_cached:-false} ${has_adds:-false} ${has_deletions:-false} ${has_deletions_cached:-false} ${has_untracked_files:-false} ${ready_to_commit:-false} ${tag_at_current_commit:-""} ${is_on_a_tag:-false} ${has_upstream:-false} ${commits_ahead:-false} ${commits_behind:-false} ${has_diverged:-false} ${should_push:-false} ${will_rebase:-false} ${has_stashes:-false} ${action})"
     
 }
+
+function_exists() {
+    declare -f -F $1 > /dev/null
+    return $?
+}
+
+function eval_prompt_callback_if_present {
+        function_exists omg_prompt_callback && echo "$(omg_prompt_callback)"
+}

--- a/prompt.sh
+++ b/prompt.sh
@@ -157,15 +157,26 @@ if [ -n "${BASH_VERSION}" ]; then
                 fi
             fi
             prompt+=$(enrich_append ${is_on_a_tag} "${omg_is_on_a_tag_symbol} ${tag_at_current_commit}" "${black_on_red}")
-            prompt+="${red_on_black}${reset}
-${omg_second_line}"
+            prompt+="${red_on_black}${reset}\n"
+            prompt+="$(eval_prompt_callback_if_present)"
+            prompt+="${omg_second_line}"
         else
-            prompt="${omg_ungit_prompt}"
+            prompt+="$(eval_prompt_callback_if_present)"
+            prompt+="${omg_ungit_prompt}"
         fi
-        
+
         echo "${prompt}"
     }
 
+    function_exists() {
+        declare -f -F $1 > /dev/null
+        return $?
+    }
+
+    function eval_prompt_callback_if_present {
+        function_exists omg_prompt_callback && echo "$(omg_prompt_callback)"
+    }
+    
     PS2="${yellow}→${reset} "
 
     source ${DIR}/base.sh

--- a/prompt.sh
+++ b/prompt.sh
@@ -2,6 +2,7 @@ PSORG=$PS1;
 
 if [ -n "${BASH_VERSION}" ]; then
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    source ${DIR}/base.sh
 
     : ${omg_ungit_prompt:=$PS1}
     : ${omg_second_line:='\w • '}
@@ -167,19 +168,9 @@ if [ -n "${BASH_VERSION}" ]; then
 
         echo "${prompt}"
     }
-
-    function_exists() {
-        declare -f -F $1 > /dev/null
-        return $?
-    }
-
-    function eval_prompt_callback_if_present {
-        function_exists omg_prompt_callback && echo "$(omg_prompt_callback)"
-    }
     
     PS2="${yellow}→${reset} "
 
-    source ${DIR}/base.sh
     function bash_prompt() {
         PS1="$(build_prompt)"
     }


### PR DESCRIPTION
This PL is aimed to solve the issue #38. It is an alternative to the solution submitted by @andreagrandi in the PL https://github.com/arialdomartini/oh-my-git/pull/35

In the shell startup file, the user can define a callback function whose output is a generic segment of the prompt.

The function can perform any operations, and have any custom output.

As for the issue #38 , a function like the following, that displays the virtualenv name if present, can be used

```shell
function omg_prompt_callback() {
    if [ -n "${VIRTUAL_ENV}" ]; then
        echo "\e[0;31m(`basename ${VIRTUAL_ENV}`)\e[0m "
    fi
}
```

oh-my-git would invoke the function above and display its output in the second line of the prompt, with this result

![screen shot 2015-01-22 at 09 12 45](https://cloud.githubusercontent.com/assets/150719/5852429/e50d18a6-a216-11e4-9b0e-c902f47a1ca4.png)


Note that the virtualenv name is displayed in the second line, with a custom color. In bash, without this PL, no virtual name would be displayed. In zsh the virtualenv name would be displayed **before** the prompt, like showed below

![screen shot 2015-01-22 at 08 57 08](https://cloud.githubusercontent.com/assets/150719/5852434/06933e88-a217-11e4-81a0-153c5a300b0a.png)


If no ```omg_prompt_callback``` is defined, no invocation is performed.

In order to disable the ordinary injection of the virtualenv name by the script ```activate```, the user can add the line

```shell
VIRTUAL_ENV_DISABLE_PROMPT=true
```

to the shell startup file.