### PR TITLE
Do not build prompt if history did not change

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -172,7 +172,12 @@ if [ -n "${BASH_VERSION}" ]; then
     PS2="${yellow}→${reset} "
 
     function bash_prompt() {
-        PS1="$(build_prompt)"
+    	local tmpfile="${TMPDIR-/tmp}/oh-my-git~"
+	local old=$(cat "$tmpfile" 2>/dev/null)
+	local new=$(history 1 | head -1 | cut -d' ' -f3 | tee "$tmpfile" 2>/dev/null)
+	if [ "$new" != "$old" ]; then
+        	PS1="$(build_prompt)"
+	fi
     }
 
     PROMPT_COMMAND=bash_prompt


### PR DESCRIPTION
Problem: if you keep hitting enter in the command line, it rebuilds the prompt and it's slow.

Not sure what's the best way to fix this, but I thought about checking the history number.