### PR TITLE
In bash, the second line is by default equal to the original PS1

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -5,7 +5,7 @@ if [ -n "${BASH_VERSION}" ]; then
     source ${DIR}/base.sh
 
     : ${omg_ungit_prompt:=$PS1}
-    : ${omg_second_line:='\w • '}
+    : ${omg_second_line:=$PS1}
 
     : ${omg_is_a_git_repo_symbol:=''}
     : ${omg_has_untracked_files_symbol:=''}        #                ?    


### PR DESCRIPTION
Currently, the default prompt outside a repo is equal to the original `PS1` defined by the user.

Yet, when in a git repo, the second line is defaulted to `\w • `, which is confusing.

With this PR the default second line is by default the original `PS1`.

Note that the user is still free to define the two prompts by using `omg_ungit_prompt` and `omg_second_line`.