### PR TITLE
improve readability of yellow and red on white

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -78,7 +78,7 @@ if [ -n "${BASH_VERSION}" ]; then
         local blue='\e[0;34m'
         local purple='\e[0;35m'
         local cyan='\e[0;36m'
-        local white='\e[0;37m'
+        local white='\e[1;30;47m'
 
         #background
         local background_black='\e[40m'
@@ -88,7 +88,7 @@ if [ -n "${BASH_VERSION}" ]; then
         local background_blue='\e[44m'
         local background_purple='\e[45m'
         local background_cyan='\e[46m'
-        local background_white='\e[47m'
+        local background_white='\e[100m'
         
         local reset='\e[0m'     # Text Reset]'
         local default_background='\e[0;31m\e[49m'

--- a/prompt.sh
+++ b/prompt.sh
@@ -25,10 +25,9 @@ if [ -n "${BASH_VERSION}" ]; then
     : ${omg_merge_tracking_branch_symbol:=''}      #  
     : ${omg_should_push_symbol:=''}                #    
     : ${omg_has_stashes_symbol:=''}
-
+    
     : ${omg_default_color_on:='\[\033[1;37m\]'}
     : ${omg_default_color_off:='\[\033[0m\]'}
-    : ${omg_last_symbol_color:='\e[0;31m\e[40m'}
     
     PROMPT='$(build_prompt)'
     RPROMPT='%{$reset_color%}%T %{$fg_bold[white]%} %n@%m%{$reset_color%}'
@@ -92,6 +91,7 @@ if [ -n "${BASH_VERSION}" ]; then
         local background_white='\e[47m'
         
         local reset='\e[0m'     # Text Reset]'
+        local default_background='\e[0;31m\e[49m'
 
         local black_on_white="${black}${background_white}"
         local yellow_on_white="${yellow}${background_white}"
@@ -159,7 +159,7 @@ if [ -n "${BASH_VERSION}" ]; then
                 fi
             fi
             prompt+=$(enrich_append ${is_on_a_tag} "${omg_is_on_a_tag_symbol} ${tag_at_current_commit}" "${black_on_red}")
-            prompt+="${omg_last_symbol_color}${reset}\n"
+            prompt+="${reset}${red}${default_background}${reset}\n"
             prompt+="$(eval_prompt_callback_if_present)"
             prompt+="${omg_second_line}"
         else


### PR DESCRIPTION
Remake of pr #54 off of a topic branch.

Changes background white to a darker grey to improve readability. 
In the screenshots the yellow on white is relatively readable. On a mac it's damn hard to see and the red isn't much better. Regardless, this darker grey should improve readability on all systems. 

![1__bash](https://cloud.githubusercontent.com/assets/2829/6051102/26f30c90-ac93-11e4-9399-030b1e5dc58c.png)

Please note that this PR actually brings one of your own commits in. I'll rebase and get rid of it if you don't want it. I left it because it looks like you wanted that change, but maybe it just hadn't made it to master yet. I forget how I got ahold of it. 