### PR TITLE
Correct stash handling

### DIFF
--- a/base.sh
+++ b/base.sh
@@ -100,11 +100,7 @@ function build_prompt {
         
             local will_rebase=$(git config --get branch.${current_branch}.rebase 2> /dev/null)
         
-            if [[ -f ${GIT_DIR:-.git}/refs/stash ]]; then
-                local number_of_stashes="$(wc -l 2> /dev/null < ${GIT_DIR:-.git}/refs/stash)"
-            else
-                local number_of_stashes=0
-            fi
+            local number_of_stashes="$(git stash list -n1 2> /dev/null | wc -l)"
             if [[ $number_of_stashes -gt 0 ]]; then local has_stashes=true; fi
         fi
     fi


### PR DESCRIPTION
oh-my-git would count the lines in `.git/refs/stash`, which wouldn't even work properly most of the time. This fixes the issue.

#57 is related. `number_of_stashes` is still 0 or 1, but I don't think this is a problem as we don't make use of `number_of_stashes` being greater than 1.