### PR TITLE
Don't override the original prompt command, append the new OMG prompt…

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -1,4 +1,5 @@
 PSORG=$PS1;
+PROMPT_COMMAND_ORG=$PROMPT_COMMAND;
 
 if [ -n "${BASH_VERSION}" ]; then
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -176,6 +177,6 @@ if [ -n "${BASH_VERSION}" ]; then
         PS1="$(build_prompt)"
     }
 
-    PROMPT_COMMAND=bash_prompt
+    PROMPT_COMMAND="bash_prompt; $PROMPT_COMMAND_ORG"
 
 fi


### PR DESCRIPTION
I'm using an additional script to generate a prompt for SVN. With the small modification both scripts can be used to generate a prompt for Git/SVN. Perhaps it's also useful for other cases...