### PR TITLE
Add indicators for interactive rebase and bisect

### DIFF
--- a/base.sh
+++ b/base.sh
@@ -111,11 +111,17 @@ function build_prompt {
                 local bisect_remain=$(git bisect view --pretty=oneline 2> /dev/null | wc -l)
                 local bisect_remain=$(bc <<< "${bisect_remain} / 2")
                 local bisect_tested=$(bc <<< "${bisect_total} - ${bisect_remain}")
+                if [[ ${bisect_remain} -ne 0 ]]; then
+                    local bisect_steps=$(bc -l <<< "a=l(${bisect_remain})/l(2); scale=0; (a+0.5)/1")
+                    local bisect_steps="~${bisect_steps}"
+                else
+                    local bisect_steps="0"
+                fi
             fi
         fi
     fi
     
-    echo "$(custom_build_prompt ${enabled:-true} ${current_commit_hash:-""} ${is_a_git_repo:-false} ${current_branch:-""} ${detached:-false} ${just_init:-false} ${has_upstream:-false} ${has_modifications:-false} ${has_modifications_cached:-false} ${has_adds:-false} ${has_deletions:-false} ${has_deletions_cached:-false} ${has_untracked_files:-false} ${ready_to_commit:-false} ${tag_at_current_commit:-""} ${is_on_a_tag:-false} ${has_upstream:-false} ${commits_ahead:-false} ${commits_behind:-false} ${has_diverged:-false} ${should_push:-false} ${will_rebase:-false} ${has_stashes:-false} ${bisect_tested:-""} ${bisect_total:-""} ${action})"
+    echo "$(custom_build_prompt ${enabled:-true} ${current_commit_hash:-""} ${is_a_git_repo:-false} ${current_branch:-""} ${detached:-false} ${just_init:-false} ${has_upstream:-false} ${has_modifications:-false} ${has_modifications_cached:-false} ${has_adds:-false} ${has_deletions:-false} ${has_deletions_cached:-false} ${has_untracked_files:-false} ${ready_to_commit:-false} ${tag_at_current_commit:-""} ${is_on_a_tag:-false} ${has_upstream:-false} ${commits_ahead:-false} ${commits_behind:-false} ${has_diverged:-false} ${should_push:-false} ${will_rebase:-false} ${has_stashes:-false} ${bisect_tested:-""} ${bisect_total:-""} ${bisect_steps:-""} ${action})"
     
 }
 

--- a/base.sh
+++ b/base.sh
@@ -101,10 +101,21 @@ function build_prompt {
         
             local number_of_stashes="$(git stash list -n1 2> /dev/null | wc -l)"
             if [[ $number_of_stashes -gt 0 ]]; then local has_stashes=true; fi
+
+            if [ "${action}" = "bisect" ]; then
+                local bisect_log=$(git bisect log)
+                local bisect_first=$(grep 'git bisect good' <<< "${bisect_log}" | head -n1 | cut -d' ' -f4)
+                local bisect_last=$(grep 'git bisect bad' <<< "${bisect_log}" | head -n1 | cut -d' ' -f4)
+                local bisect_total=$(git log --pretty=oneline ${bisect_first}..${bisect_last} 2> /dev/null | wc -l)
+                local bisect_total=$(bc <<< "${bisect_total} - 1")
+                local bisect_remain=$(git bisect view --pretty=oneline 2> /dev/null | wc -l)
+                local bisect_remain=$(bc <<< "${bisect_remain} / 2")
+                local bisect_tested=$(bc <<< "${bisect_total} - ${bisect_remain}")
+            fi
         fi
     fi
     
-    echo "$(custom_build_prompt ${enabled:-true} ${current_commit_hash:-""} ${is_a_git_repo:-false} ${current_branch:-""} ${detached:-false} ${just_init:-false} ${has_upstream:-false} ${has_modifications:-false} ${has_modifications_cached:-false} ${has_adds:-false} ${has_deletions:-false} ${has_deletions_cached:-false} ${has_untracked_files:-false} ${ready_to_commit:-false} ${tag_at_current_commit:-""} ${is_on_a_tag:-false} ${has_upstream:-false} ${commits_ahead:-false} ${commits_behind:-false} ${has_diverged:-false} ${should_push:-false} ${will_rebase:-false} ${has_stashes:-false} ${action})"
+    echo "$(custom_build_prompt ${enabled:-true} ${current_commit_hash:-""} ${is_a_git_repo:-false} ${current_branch:-""} ${detached:-false} ${just_init:-false} ${has_upstream:-false} ${has_modifications:-false} ${has_modifications_cached:-false} ${has_adds:-false} ${has_deletions:-false} ${has_deletions_cached:-false} ${has_untracked_files:-false} ${ready_to_commit:-false} ${tag_at_current_commit:-""} ${is_on_a_tag:-false} ${has_upstream:-false} ${commits_ahead:-false} ${commits_behind:-false} ${has_diverged:-false} ${should_push:-false} ${will_rebase:-false} ${has_stashes:-false} ${bisect_tested:-""} ${bisect_total:-""} ${action})"
     
 }
 

--- a/prompt.sh
+++ b/prompt.sh
@@ -23,6 +23,7 @@ if [ -n "${BASH_VERSION}" ]; then
     : ${omg_has_diverged_symbol:=''}               #   
     : ${omg_not_tracked_branch_symbol:=''}
     : ${omg_rebase_tracking_branch_symbol:=''}     #   
+    : ${omg_rebase_interactive_symbol:=''}
     : ${omg_merge_tracking_branch_symbol:=''}      #  
     : ${omg_should_push_symbol:=''}                #    
     : ${omg_has_stashes_symbol:=''}
@@ -67,6 +68,7 @@ if [ -n "${BASH_VERSION}" ]; then
         local should_push=${21}
         local will_rebase=${22}
         local has_stashes=${23}
+        local action=${24}
 
         local prompt=""
         local original_prompt=$PS1
@@ -130,7 +132,11 @@ if [ -n "${BASH_VERSION}" ]; then
 
             prompt="${prompt} ${white_on_red} ${black_on_red}"
             if [[ $detached == true ]]; then
-                prompt+=$(enrich_append $detached $omg_detached_symbol "${white_on_red}")
+                if [[ "${action}" = "rebase" ]]; then
+                    prompt+=$(enrich_append $detached $omg_rebase_interactive_symbol "${white_on_red}")
+                else
+                    prompt+=$(enrich_append $detached $omg_detached_symbol "${white_on_red}")
+                fi
                 prompt+=$(enrich_append $detached "(${current_commit_hash:0:7})" "${black_on_red}")
             else            
                 if [[ $has_upstream == false ]]; then

--- a/prompt.sh
+++ b/prompt.sh
@@ -69,7 +69,9 @@ if [ -n "${BASH_VERSION}" ]; then
         local should_push=${21}
         local will_rebase=${22}
         local has_stashes=${23}
-        local action=${24}
+        local bisect_remain=${24}
+        local bisect_total=${25}
+        local action=${26}
 
         local prompt=""
         local original_prompt=$PS1
@@ -136,7 +138,7 @@ if [ -n "${BASH_VERSION}" ]; then
                 if [[ "${action}" = "rebase" ]]; then
                     prompt+=$(enrich_append $detached $omg_rebase_interactive_symbol "${white_on_red}")
                 elif [[ "${action}" = "bisect" ]]; then
-                    prompt+=$(enrich_append $detached $omg_bisect_symbol "${white_on_red}")
+                    prompt+=$(enrich_append $detached "${bisect_tested}/${bisect_total} $omg_bisect_symbol" "${white_on_red}")
                 else
                     prompt+=$(enrich_append $detached $omg_detached_symbol "${white_on_red}")
                 fi

--- a/prompt.sh
+++ b/prompt.sh
@@ -71,7 +71,8 @@ if [ -n "${BASH_VERSION}" ]; then
         local has_stashes=${23}
         local bisect_remain=${24}
         local bisect_total=${25}
-        local action=${26}
+        local bisect_steps=${26}
+        local action=${27}
 
         local prompt=""
         local original_prompt=$PS1
@@ -138,7 +139,7 @@ if [ -n "${BASH_VERSION}" ]; then
                 if [[ "${action}" = "rebase" ]]; then
                     prompt+=$(enrich_append $detached $omg_rebase_interactive_symbol "${white_on_red}")
                 elif [[ "${action}" = "bisect" ]]; then
-                    prompt+=$(enrich_append $detached "${bisect_tested}/${bisect_total} $omg_bisect_symbol" "${white_on_red}")
+                    prompt+=$(enrich_append $detached "${bisect_tested}/${bisect_total} $omg_bisect_symbol  ${bisect_steps}" "${white_on_red}")
                 else
                     prompt+=$(enrich_append $detached $omg_detached_symbol "${white_on_red}")
                 fi

--- a/prompt.sh
+++ b/prompt.sh
@@ -24,6 +24,7 @@ if [ -n "${BASH_VERSION}" ]; then
     : ${omg_not_tracked_branch_symbol:=''}
     : ${omg_rebase_tracking_branch_symbol:=''}     #   
     : ${omg_rebase_interactive_symbol:=''}
+    : ${omg_bisect_symbol:=''}
     : ${omg_merge_tracking_branch_symbol:=''}      #  
     : ${omg_should_push_symbol:=''}                #    
     : ${omg_has_stashes_symbol:=''}
@@ -134,6 +135,8 @@ if [ -n "${BASH_VERSION}" ]; then
             if [[ $detached == true ]]; then
                 if [[ "${action}" = "rebase" ]]; then
                     prompt+=$(enrich_append $detached $omg_rebase_interactive_symbol "${white_on_red}")
+                elif [[ "${action}" = "bisect" ]]; then
+                    prompt+=$(enrich_append $detached $omg_bisect_symbol "${white_on_red}")
                 else
                     prompt+=$(enrich_append $detached $omg_detached_symbol "${white_on_red}")
                 fi


### PR DESCRIPTION
These commits add support for several nice conveniences:
- A wrench indicator for interactive rebase.
- A binoculars indicator for bisecting.
- Revision progress for bisecting (tested commits / commits remaining).
- Approximate number of remaining bisect steps.

I don't know about everyone else, but rebasing and bisecting are a critical part of my workflow and having indications for that helps me to avoid making a lot of mistakes.