### PR TITLE
Fix fatal error if not in git dir

### DIFF
--- a/base.sh
+++ b/base.sh
@@ -49,7 +49,7 @@ function get_current_action () {
 }
 
 function build_prompt {
-    local enabled=`git config --local --get oh-my-git.enabled`
+    local enabled=`git config --get oh-my-git.enabled`
     if [[ ${enabled} == false ]]; then
         echo "${PSORG}"
         exit;


### PR DESCRIPTION
following command throws an error in git 2.13.0 macosx:
> git config --local --get oh-my-git.enabled
fatal: BUG: setup_git_env called without repository 
(appears in base.sh:49)

this fix pipes the "fatal..." output to /dev/null (as you already do in every other git command :-)
