### PR TITLE
Prevent PROMPT_COMMAND from duplicating OMG's bash_prompt command

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,46 +170,6 @@ Those are just default values. If you wish to use another glyph for untracked fi
 in your shell startup file.
 
 ---
-#### With Bash the last symbol looks very bad, like this
-
-![oh-my-git](https://cloud.githubusercontent.com/assets/6009528/6031476/0b9bfe2c-ac00-11e4-898a-324a71be6cb5.png)
-
-**A**: Unfortunately, I haven't find a way to tell bash "*print the next symbol using the background color currently used by the terminal*" and as far as I know [there's no way to achieve this result](http://unix.stackexchange.com/questions/1755/change-the-ps1-color-based-on-the-background-color#tab-top). Zsh is not affected by this issue, but bash is.
-
-As a consequence, when printing the last symbol, oh-my-git has no choice but setting explicitly the foreground and background colors. Currently, the standard background color is black. This is unfortunate, because if the terminal uses a different background color than black, the result is bad, as showed in the above screenshot.
-
-A smart solution is the one proposed by [@Sgiath](https://github.com/Sgiath): in the color palette set the first color (the one in the top-left corner) same as background color, like this
-
-![oh-my-git](https://cloud.githubusercontent.com/assets/6009528/6039646/454c965e-ac69-11e4-8f80-37425181d04b.png)
-
-This in fact sets the "black" color to the same color used as the terminal background.
-
-
-If for any reasons you cannot change the palette, you can override the colors used to render the last symbol with the variable `omg_last_symbol_color`.
-
-For example, if the terminal is using a gray background, you can add a
-
-```
-background=240
-red='\e[0;31m'
-omg_last_symbol_color="${red}\[\033[48;5;${background}m\]"
-```
-
-to your `.bashrc` and fix the issue by choosing the right value for `background`.
-
-You can use
-
-```
-foreground=160
-background=240
-omg_last_symbol_color="\[\033[38;5;${foreground}m\]\[\033[48;5;${background}m\]"
-```
-
-if you want a more detailed control on the colors.
-
-Finding the right value is not trivial. Please, refer to [this page](http://bitmote.com/index.php?post/2012/11/19/Using-ANSI-Color-Codes-to-Colorize-Your-Bash-Prompt-on-Linux) for a the 256 colors code table.
-
----
 
 #### On OS X, I configured iTerm2 with the patched font, but the prompt is still broken.
 

--- a/base.sh
+++ b/base.sh
@@ -63,7 +63,8 @@ function build_prompt {
     
     if [[ $is_a_git_repo == true ]]; then
         local current_branch=$(git rev-parse --abbrev-ref HEAD 2> /dev/null)
-        if [[ $current_branch == 'HEAD' ]]; then local detached=true; fi
+        local current_branch_sanitized=${current_branch//\$/💩}
+        if [[ $current_branch_sanitized == 'HEAD' ]]; then local detached=true; fi
 
         local number_of_logs="$(git log --pretty=oneline -n1 2> /dev/null | wc -l)"
         if [[ $number_of_logs -eq 0 ]]; then
@@ -97,14 +98,14 @@ function build_prompt {
             if [[ $commits_ahead -gt 0 && $commits_behind -gt 0 ]]; then local has_diverged=true; fi
             if [[ $has_diverged == false && $commits_ahead -gt 0 ]]; then local should_push=true; fi
         
-            local will_rebase=$(git config --get branch.${current_branch}.rebase 2> /dev/null)
+            local will_rebase=$(git config --get branch.${current_branch_sanitized}.rebase 2> /dev/null)
         
             local number_of_stashes="$(git stash list -n1 2> /dev/null | wc -l)"
             if [[ $number_of_stashes -gt 0 ]]; then local has_stashes=true; fi
         fi
     fi
     
-    echo "$(custom_build_prompt ${enabled:-true} ${current_commit_hash:-""} ${is_a_git_repo:-false} ${current_branch:-""} ${detached:-false} ${just_init:-false} ${has_upstream:-false} ${has_modifications:-false} ${has_modifications_cached:-false} ${has_adds:-false} ${has_deletions:-false} ${has_deletions_cached:-false} ${has_untracked_files:-false} ${ready_to_commit:-false} ${tag_at_current_commit:-""} ${is_on_a_tag:-false} ${has_upstream:-false} ${commits_ahead:-false} ${commits_behind:-false} ${has_diverged:-false} ${should_push:-false} ${will_rebase:-false} ${has_stashes:-false} ${action})"
+    echo "$(custom_build_prompt ${enabled:-true} ${current_commit_hash:-""} ${is_a_git_repo:-false} ${current_branch_sanitized:-""} ${detached:-false} ${just_init:-false} ${has_upstream:-false} ${has_modifications:-false} ${has_modifications_cached:-false} ${has_adds:-false} ${has_deletions:-false} ${has_deletions_cached:-false} ${has_untracked_files:-false} ${ready_to_commit:-false} ${tag_at_current_commit:-""} ${is_on_a_tag:-false} ${has_upstream:-false} ${commits_ahead:-false} ${commits_behind:-false} ${has_diverged:-false} ${should_push:-false} ${will_rebase:-false} ${has_stashes:-false} ${action})"
     
 }
 

--- a/prompt.sh
+++ b/prompt.sh
@@ -29,7 +29,6 @@ if [ -n "${BASH_VERSION}" ]; then
 
     : ${omg_default_color_on:='\[\033[1;37m\]'}
     : ${omg_default_color_off:='\[\033[0m\]'}
-    : ${omg_last_symbol_color:='\e[0;31m\e[40m'}
     
     PROMPT='$(build_prompt)'
     RPROMPT='%{$reset_color%}%T %{$fg_bold[white]%} %n@%m%{$reset_color%}'
@@ -160,7 +159,7 @@ if [ -n "${BASH_VERSION}" ]; then
                 fi
             fi
             prompt+=$(enrich_append ${is_on_a_tag} "${omg_is_on_a_tag_symbol} ${tag_at_current_commit}" "${black_on_red}")
-            prompt+="${omg_last_symbol_color}${reset}\n"
+            prompt+="${reset}${red}${reset}\n"
             prompt+="$(eval_prompt_callback_if_present)"
             prompt+="${omg_second_line}"
         else

--- a/prompt.sh
+++ b/prompt.sh
@@ -1,5 +1,5 @@
 PSORG=$PS1;
-PROMPT_COMMAND_ORG=$PROMPT_COMMAND;
+PROMPT_COMMAND_ORG=${PROMPT_COMMAND##*bash_prompt; };
 
 if [ -n "${BASH_VERSION}" ]; then
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
On my Mac, I found the `PROMPT_COMMAND` to gain an additional `bash_prompt; ` every time I reloaded my profile via an alias of `source ~/.bash_profile`.

This change will strip everything at the beginning of the original `PROMPT_COMMAND` prior to prepending `bash_prompt; `. In my one test case, this works well.