### PR TITLE
Prevent PROMPT_COMMAND from duplicating OMG's bash_prompt command

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -1,5 +1,5 @@
 PSORG=$PS1;
-PROMPT_COMMAND_ORG=$PROMPT_COMMAND;
+PROMPT_COMMAND_ORG=${PROMPT_COMMAND##*bash_prompt; };
 
 if [ -n "${BASH_VERSION}" ]; then
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
On my Mac, I found the `PROMPT_COMMAND` to gain an additional `bash_prompt; ` every time I reloaded my profile via an alias of `source ~/.bash_profile`.

This change will strip everything at the beginning of the original `PROMPT_COMMAND` prior to prepending `bash_prompt; `. In my one test case, this works well.