### PR TITLE
Fix support virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Add
 VIRTUAL_ENV_DISABLE_PROMPT=true
 function omg_prompt_callback() {
     if [ -n "${VIRTUAL_ENV}" ]; then
-        echo "\e[0;31m(`basename ${VIRTUAL_ENV}`)\e[0m "
+        echo "\[\e[0;31m\](`basename ${VIRTUAL_ENV}`)\[\e[0m\] "
     fi
 }
 ```


### PR DESCRIPTION
It is necessary to escape ALL the non-printable characters so you can bash it correctly.
It is necessary to escape the full character (`\e[0;31m`) by using: `\[...\]`, with `"\[\e[0;31m\]`, because it only takes up the first semicolon `;`
Otherwise, you can not find the entire non-printable character, and the bash does not have a normal behavior.

**Ex when you print a long line:**
```
(name_virtualenv) user@user-pc:~$ aa
aaaaairtualenv) user@user-pc:~$ aaaaaaaaaaaaaaaaaaaaaaaa
```

Now, this causes the non-printable characters to escape correctly