### PR TITLE
Last symbol background set to transparent

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -29,7 +29,7 @@ if [ -n "${BASH_VERSION}" ]; then
 
     : ${omg_default_color_on:='\[\033[1;37m\]'}
     : ${omg_default_color_off:='\[\033[0m\]'}
-    : ${omg_last_symbol_color:='\e[0;31m\e[40m'}
+    : ${omg_last_symbol_color:='\e[0;31m\e[49m'}
     
     PROMPT='$(build_prompt)'
     RPROMPT='%{$reset_color%}%T %{$fg_bold[white]%} %n@%m%{$reset_color%}'


### PR DESCRIPTION
Set the background to the last symbol to be transparent for terminals with non-black background colors