### PR TITLE
Retain the old return code when executing the bash_prompt changes.

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -174,7 +174,9 @@ if [ -n "${BASH_VERSION}" ]; then
     PS2="${yellow}→${reset} "
 
     function bash_prompt() {
+        local oldrc=$?
         PS1="$(build_prompt)"
+        return $oldrc
     }
 
     PROMPT_COMMAND="bash_prompt; $PROMPT_COMMAND_ORG"


### PR DESCRIPTION
The 'bash_prompt' function was not preserving the return code between
calls to it. If other PROMPT_COMMAND executions were to rely on the
return code - say, to change the value of a variable that would be
substituted into the PS1 value to indicate the return code - this
would be broken, causing such functions to break.

This change preserves the return code such that the subsequent prompt
command executions can take advantage of the value of the prior
executed commands return.