### PR TITLE
Simple fix for bad background color on last prompt character.

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -29,7 +29,7 @@ if [ -n "${BASH_VERSION}" ]; then
 
     : ${omg_default_color_on:='\[\033[1;37m\]'}
     : ${omg_default_color_off:='\[\033[0m\]'}
-    : ${omg_last_symbol_color:='\e[0;31m\e[40m'}
+    : ${omg_last_symbol_color:='\e[0;31m'}
     
     PROMPT='$(build_prompt)'
     RPROMPT='%{$reset_color%}%T %{$fg_bold[white]%} %n@%m%{$reset_color%}'
@@ -160,7 +160,7 @@ if [ -n "${BASH_VERSION}" ]; then
                 fi
             fi
             prompt+=$(enrich_append ${is_on_a_tag} "${omg_is_on_a_tag_symbol} ${tag_at_current_commit}" "${black_on_red}")
-            prompt+="${omg_last_symbol_color}${reset}\n"
+            prompt+="${reset}${omg_last_symbol_color}${reset}\n"
             prompt+="$(eval_prompt_callback_if_present)"
             prompt+="${omg_second_line}"
         else


### PR DESCRIPTION
I fear this repo has been abandoned... and it looks like this issue has been addressed in some previous pull requests (which have not been accepted or closed).  But the fix seems simple to me, so I'll risk my time by offering it again...  

My fix just involves doing a full reset, and then setting only the *foreground* color before emitting the last character.  I haven't run across any terminal emulators (in any color-enabled modes) where this doesn't work.  If I've missed some case(s) where this won't work, please share the specifics. 