### PR TITLE
commits_ahead and commits_behind are in correct order

### DIFF
--- a/base.sh
+++ b/base.sh
@@ -90,7 +90,7 @@ function build_prompt {
         
             if [[ $has_upstream == true ]]; then
                 local commits_ahead commits_behind
-                read -r commits_behind commits_ahead <<<$(git rev-list --left-right --count ${current_commit_hash}...${upstream} 2> /dev/null)
+                read -r commits_ahead commits_behind <<<$(git rev-list --left-right --count ${current_commit_hash}...${upstream} 2> /dev/null)
             fi
 
             if [[ $commits_ahead -gt 0 && $commits_behind -gt 0 ]]; then local has_diverged=true; fi


### PR DESCRIPTION
The 2 variables were mixed up, resulting in switched values.
Thank you @p-himik